### PR TITLE
Ignore typescript buildinfo in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+dist/tsconfig.tsbuildinfo


### PR DESCRIPTION
We can also ignore the typescript build information for an even smaller package.